### PR TITLE
add meta viewport tags to improve layouts on mobile devices

### DIFF
--- a/var/www/html/supermon/astlog.php
+++ b/var/www/html/supermon/astlog.php
@@ -13,6 +13,7 @@ include("common.inc");
 <html>
 <head>
   <title>Asterisk messages Log</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body>
 <pre>

--- a/var/www/html/supermon/astlookup.php
+++ b/var/www/html/supermon/astlookup.php
@@ -17,6 +17,7 @@ $perm = @trim(strip_tags($_GET['perm']));
 ?>
 <html>
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="astlookup.css"/>
   <title>Opening information for: <?php
       echo "$node"; ?></title>

--- a/var/www/html/supermon/connectlog.php
+++ b/var/www/html/supermon/connectlog.php
@@ -11,6 +11,7 @@ include("session.inc");
 <html>
 <head>
   <title>AllStar Connection Log</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body>
 <pre>

--- a/var/www/html/supermon/controlpanel.php
+++ b/var/www/html/supermon/controlpanel.php
@@ -59,6 +59,7 @@ if ($_SESSION['sm61loggedin'] === true) {
       echo $title; ?></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="generator" content="By hand with a text editor">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="AllStar Control Panel">
   <meta name="keywords" content="allstar monitor, app_rpt, asterisk">
   <meta name="author" content="Tim Sawyer, WD6AWP">

--- a/var/www/html/supermon/cpustats.php
+++ b/var/www/html/supermon/cpustats.php
@@ -10,6 +10,7 @@ include("session.inc");
 ?>
 <html>
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>CPU and System Status</title>
 </head>
 <body>

--- a/var/www/html/supermon/display-config.php
+++ b/var/www/html/supermon/display-config.php
@@ -16,6 +16,7 @@
 -->
 
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link type="text/css" rel="stylesheet" href="supermon.css">
 
   <script>

--- a/var/www/html/supermon/edit/configeditor.php
+++ b/var/www/html/supermon/edit/configeditor.php
@@ -13,7 +13,9 @@ include("../session.inc");
 $SUPERMON_DIR = "/var/www/html/supermon";
 
 include("../global.inc");
-print "<html>\n<body style=\"background-color:powderblue;\">\n";
+print "<html>";
+print "<head><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"></head>";
+print "<body style=\"background-color:powderblue;\">\n";
 print "<font face=Arial size=2>\n";
 if ($_SESSION['sm61loggedin'] === true) {
     print "<form name=REFRESH method=POST action='./configeditor.php'>";

--- a/var/www/html/supermon/edit/edit.php
+++ b/var/www/html/supermon/edit/edit.php
@@ -7,6 +7,7 @@ include("../session.inc");
 // Be sure to allow popups from your Allmon web server to your browser!!
 // Changes: KB4FXC 2018-02-04
 
+print "<head><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"></head>";
 if ($_SESSION['sm61loggedin'] !== true) {
     die ("<br><h3>ERROR: You Must login to use the 'Edit' function!</h3>");
 }

--- a/var/www/html/supermon/favorites.php
+++ b/var/www/html/supermon/favorites.php
@@ -47,6 +47,7 @@ if ($_SESSION['sm61loggedin'] === true) {
       echo $title; ?></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="generator" content="By hand with a text editor">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="SuperMon Favorites Panel">
   <meta name="keywords" content="allstar monitor, app_rpt, asterisk">
   <meta name="author" content="Tim Sawyer, WD6AWP">

--- a/var/www/html/supermon/header.inc
+++ b/var/www/html/supermon/header.inc
@@ -49,6 +49,7 @@ if (!empty($var1[1])) {
   <meta name="robots" content="noindex, nofollow">
   <meta name="author" content="Tim Sawyer, WD6AWP">
   <meta name="mods" content="New features, IRLP capability, Paul Aidukas, KN2R">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
   <link rel="icon" href="favicon.ico" type="image/x-icon">
   <link type="text/css" rel="stylesheet" href="supermon.css">

--- a/var/www/html/supermon/linuxlog.php
+++ b/var/www/html/supermon/linuxlog.php
@@ -12,6 +12,7 @@ include("common.inc");
 <html>
 <head>
   <title>Linux messages Log</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body>
 <pre>

--- a/var/www/html/supermon/lsnodes/lsnodes_form.php
+++ b/var/www/html/supermon/lsnodes/lsnodes_form.php
@@ -15,6 +15,7 @@ if (!file_exists("/var/www/html/lsnodes/lsnodes_no_supermon_pw")) {
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Allstar Node and Command Entry</title>
   <link rel="stylesheet" type="text/css" media="screen" href="css-form.css"/>
 

--- a/var/www/html/supermon/node-ban-allow-intro.php
+++ b/var/www/html/supermon/node-ban-allow-intro.php
@@ -16,6 +16,7 @@ if ($_SESSION['sm61loggedin'] !== true) {
 -->
 
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link type="text/css" rel="stylesheet" href="supermon.css">
 </head>
 <body style="background-color:powderblue;">

--- a/var/www/html/supermon/node-ban-allow.php
+++ b/var/www/html/supermon/node-ban-allow.php
@@ -16,6 +16,7 @@ if ($_SESSION['sm61loggedin'] !== true) {
 -->
 
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link type="text/css" rel="stylesheet" href="supermon.css">
 </head>
 <body style="background-color: powderblue;">

--- a/var/www/html/supermon/pi-gpio.php
+++ b/var/www/html/supermon/pi-gpio.php
@@ -14,6 +14,7 @@ if ($_SESSION['sm61loggedin'] !== true) {
 -->
 
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link type="text/css" rel="stylesheet" href="supermon.css">
 </head>
 <body style="background-color:powderblue;">

--- a/var/www/html/supermon/rptstats.php
+++ b/var/www/html/supermon/rptstats.php
@@ -9,6 +9,7 @@ include("amifunctions.inc");
 // Be sure to allow popups from your Allmon web server to your browser!!
 // Major update by KB4FXC 02/2018
 
+print "<head><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"></head>";
 $node = (int) trim(strip_tags($_GET['node']));
 $localnode = (int) trim(strip_tags($_GET['localnode']));
 

--- a/var/www/html/supermon/webacclog.php
+++ b/var/www/html/supermon/webacclog.php
@@ -13,6 +13,7 @@ include("common.inc");
 <html>
 <head>
   <title>Web Server access_log</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body>
 <pre>

--- a/var/www/html/supermon/weberrlog.php
+++ b/var/www/html/supermon/weberrlog.php
@@ -13,6 +13,7 @@ include("common.inc");
 <html>
 <head>
   <title>Web Server error_log</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body>
 <pre>


### PR DESCRIPTION
Adding this viewport tag doesn't change the desktop website, but helps to scale buttons and text on mobile devices, so supermon is easier to use from a smartphone. I'm not even sure I got all of the pages, but did go through the buttons and menus and fixed the pages that didn't have proper scaling on my phone and then re-tested with these changes.